### PR TITLE
Fix container vs name issue

### DIFF
--- a/dockermap/map/client.py
+++ b/dockermap/map/client.py
@@ -168,8 +168,9 @@ class MappingDockerClient(object):
                 a_kwargs = kwargs or {}
             if action == ACTION_CREATE:
                 image = a_kwargs.pop('image')
+                name = a_kwargs.pop('name', container)
                 self._ensure_images(map_name, image)
-                yield client.create_container(image, container, **a_kwargs)
+                yield client.create_container(image, name=name, **a_kwargs)
             elif action == ACTION_START:
                 client.start(container, **a_kwargs)
             elif action == ACTION_PREPARE:


### PR DESCRIPTION
Hi,

I believe there's a small issue on create('container') method. It is assigning the command to the container name. I didn't check if this (or similar) happens on other commands, but I attach a pull request that fixes the issue for me. 
