### PR TITLE
Errors on valid input.

### DIFF
--- a/dockermap/map/client.py
+++ b/dockermap/map/client.py
@@ -36,7 +36,8 @@ class MappingDockerClient(object):
     """
     configuration_class = ClientConfiguration
 
-    def __init__(self, container_maps=None, docker_client=None, clients=None, policy_class=ResumeUpdatePolicy):
+    def __init__(self, container_maps=None, docker_client=None, clients={},
+                 policy_class=ResumeUpdatePolicy):
         if container_maps:
             if isinstance(container_maps, ContainerMap):
                 self._default_map = container_maps.name
@@ -49,11 +50,11 @@ class MappingDockerClient(object):
                 self._maps = container_maps
             else:
                 raise ValueError("Unexpected type of 'container_maps' argument: {0}".format(type(container_maps)))
-        if clients:
-            if isinstance(clients, (list, tuple)):
-                self._clients = dict(clients)
-            else:
-                self._clients = clients
+        if clients and isinstance(clients, (list, tuple)):
+            self._clients = dict(clients)
+        else:
+            self._clients = clients
+
         if docker_client:
             if isinstance(docker_client, docker.Client):
                 default_client = self.configuration_class.from_client(docker_client)

--- a/dockermap/map/config.py
+++ b/dockermap/map/config.py
@@ -510,7 +510,8 @@ class ClientConfiguration(DictMap):
         :type client: docker.client.Client
         :return: ClientConfiguration
         """
-        return cls(base_url=client.base_url, version=client._version, timeout=client._timeout, client=client)
+        return cls(base_url=client.base_url, version=client._version,
+                   timeout=client.timeout, client=client)
 
     def get_init_kwargs(self):
         """


### PR DESCRIPTION
Hello,

This PR fixes two little problems. The first one is this error:

~~~
(jenkins-test)ubuntu@rose:~/maps$ python go.py 
Traceback (most recent call last):
  File "go.py", line 6, in <module>
    map_client = MappingDockerClient(container_map, DockerClientWrapper('unix://var/run/docker.sock'))
  File "/home/ubuntu/.virtualenvs/jenkins-test/local/lib/python2.7/site-packages/dockermap/map/client.py", line 59, in __init__
    default_client = self.configuration_class.from_client(docker_client)
  File "/home/ubuntu/.virtualenvs/jenkins-test/local/lib/python2.7/site-packages/dockermap/map/config.py", line 513, in from_client
    return cls(base_url=client.base_url, version=client._version, timeout=client._timeout, client=client)
AttributeError: 'DockerClientWrapper' object has no attribute '_timeout'
~~~

And the second commit fixes this error:

~~~
Traceback (most recent call last):
  File "go.py", line 13, in <module>
    map_client = MappingDockerClient(container_map, config)
  File "/home/ubuntu/.virtualenvs/jenkins-test/local/lib/python2.7/site-packages/dockermap/map/client.py", line 65, in __init__
    self._clients[default_name] = default_client
AttributeError: 'MappingDockerClient' object has no attribute '_clients'
~~~

Greetings.