### PR TITLE
Fix tag/repo partitioning with private registries

### DIFF
--- a/dockermap/map/base.py
+++ b/dockermap/map/base.py
@@ -155,7 +155,7 @@ class DockerClientWrapper(docker.Client):
         if last_log and last_log.startswith('Successfully built '):
             image_id = last_log[19:]  # Remove prefix
             if add_latest_tag:
-                repo, __, i_tag = tag.partition(':')
+                repo, __, i_tag = tag.rpartition(':')
                 if i_tag and i_tag != 'latest':
                     self.tag(image_id, repo, 'latest', force=True)
             return image_id

--- a/dockermap/map/policy/cache.py
+++ b/dockermap/map/policy/cache.py
@@ -58,7 +58,7 @@ class CachedImages(CachedItems, dict):
         :return: Image id associated with the image name.
         :rtype: unicode
         """
-        image, __, tag = image_name.partition(':')
+        image, __, tag = image_name.rpartition(':')
         if tag:
             full_name = image_name
         else:


### PR DESCRIPTION
rpartition is needed when using colon as boundary.