### PR TITLE
Make unittests pass under Python 3.4

### DIFF
--- a/dockermap/map/base.py
+++ b/dockermap/map/base.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import sys
 import logging
 
+import six
 import docker
 from docker.errors import APIError
 
@@ -286,12 +288,10 @@ class DockerClientWrapper(docker.Client):
             try:
                 self.remove_container(cn)
             except APIError as e:
-                import sys
-                exc_info = sys.exc_info()
                 if e.response.status_code != 404:
                     self.push_log("Could not remove container '%s': %s", logging.ERROR, cn, e.explanation)
                     if raise_on_error:
-                        raise exc_info[0], exc_info[1], exc_info[2]
+                        six.reraise(*sys.exc_info())
 
     def cleanup_images(self, remove_old=False, raise_on_error=False):
         """
@@ -315,12 +315,10 @@ class DockerClientWrapper(docker.Client):
             try:
                 self.remove_image(iid)
             except APIError as e:
-                import sys
-                exc_info = sys.exc_info()
                 if e.response.status_code != 404:
                     self.push_log("Could not remove image '%s': %s", logging.ERROR, iid, e.explanation)
                     if raise_on_error:
-                        raise exc_info[0], exc_info[1], exc_info[2]
+                        six.reraise(*sys.exc_info())
 
     def get_container_names(self):
         """
@@ -373,12 +371,10 @@ class DockerClientWrapper(docker.Client):
         try:
             super(DockerClientWrapper, self).remove_container(container, **kwargs)
         except APIError as e:
-            import sys
-            exc_info = sys.exc_info()
             if e.response.status_code != 404:
                 self.push_log("Failed to stop container '%s': %s", logging.ERROR, container, e.explanation)
                 if raise_on_error:
-                    raise exc_info[0], exc_info[1], exc_info[2]
+                    six.reraise(*sys.exc_info())
 
     def stop(self, container, raise_on_error=False, **kwargs):
         """
@@ -395,12 +391,10 @@ class DockerClientWrapper(docker.Client):
         try:
             super(DockerClientWrapper, self).stop(container, **kwargs)
         except APIError as e:
-            import sys
-            exc_info = sys.exc_info()
             if e.response.status_code != 404:
                 self.push_log("Failed to remove container '%s': %s", logging.ERROR, container, e.explanation)
                 if raise_on_error:
-                    raise exc_info[0], exc_info[1], exc_info[2]
+                    six.reraise(*sys.exc_info())
 
     def remove_all_containers(self):
         """
@@ -413,18 +407,14 @@ class DockerClientWrapper(docker.Client):
                 try:
                     self.stop(c_id)
                 except APIError as e:
-                    import sys
-                    exc_info = sys.exc_info()
                     if e.response.status_code != 404:
-                        raise exc_info[0], exc_info[1], exc_info[2]
+                        six.reraise(*sys.exc_info())
         for c_id, __ in containers:
             try:
                 self.remove_container(c_id)
             except APIError as e:
-                import sys
-                exc_info = sys.exc_info()
                 if e.response.status_code != 404:
-                    raise exc_info[0], exc_info[1], exc_info[2]
+                    six.reraise(*sys.exc_info())
 
     def copy_resource(self, container, resource, local_filename):
         """

--- a/dockermap/map/input.py
+++ b/dockermap/map/input.py
@@ -19,6 +19,7 @@ CURRENT_DIR = '{0}{1}'.format(posixpath.curdir, posixpath.sep)
 class _NotSet(object):
     def __nonzero__(self):
         return False
+    __bool__ = __nonzero__
 
     def __repr__(self):
         return "<Value not set>"
@@ -117,7 +118,7 @@ def get_shared_volume(value):
     elif isinstance(value, dict):
         v_len = len(value)
         if v_len == 1:
-            k, v = value.items()[0]
+            k, v = list(value.items())[0]
             return SharedVolume(k, read_only(v))
         raise ValueError("Invalid element length; only dicts with one element can be converted to a SharedVolume "
                          "tuple. Found length {0}.".format(v_len))
@@ -174,7 +175,7 @@ def get_shared_host_volume(value):
     elif isinstance(value, dict):
         v_len = len(value)
         if v_len == 1:
-            c_path, v = value.items()[0]
+            c_path, v = list(value.items())[0]
             if isinstance(v, (list, tuple)):
                 return _shared_host_volume_from_tuple(c_path, *v)
             return _shared_host_volume_from_tuple(c_path, v)
@@ -218,7 +219,7 @@ def get_port_binding(value):
     :return: PortBinding tuple.
     :rtype: PortBinding
     """
-    sub_types = six.string_types + (int, long)
+    sub_types = six.string_types + six.integer_types
     if isinstance(value, PortBinding):
         return value
     elif isinstance(value, sub_types):  # Port only

--- a/tests/test_dependency_resolution.py
+++ b/tests/test_dependency_resolution.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import unittest
+import six
 
 from dockermap.map.base import ContainerImageResolver
 from dockermap.map.container import ContainerMap
@@ -37,7 +38,7 @@ class ContainerDependencyTest(unittest.TestCase):
 
     def assertOrder(self, dependency_list, *items):
         iterator = iter(items)
-        last_item = iterator.next()
+        last_item = six.next(iterator)
         last_idx = dependency_list.index(last_item)
         for item in iterator:
             index = dependency_list.index(item)

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import unittest
+import six
 
 from dockermap.functional import lazy_once
 from dockermap.map.input import (is_path, read_only, get_list, get_shared_volume, get_shared_volumes,
@@ -48,8 +49,8 @@ class InputConversionTest(unittest.TestCase):
 
     def test_get_shared_volumes(self):
         assert_a = lambda a: self.assertEqual(get_shared_volumes(a), [SharedVolume('a', False)])
-        assert_b = lambda b: self.assertItemsEqual(get_shared_volumes(b), [SharedVolume('a', False),
-                                                                           SharedVolume('b', True)])
+        assert_b = lambda b: six.assertCountEqual(self, get_shared_volumes(b), [SharedVolume('a', False),
+                                                                                SharedVolume('b', True)])
 
         assert_a(SharedVolume('a', False))
         assert_a('a')
@@ -81,10 +82,10 @@ class InputConversionTest(unittest.TestCase):
 
     def test_get_shared_host_volumes(self):
         assert_a = lambda a: self.assertEqual(get_shared_host_volumes(a), [SharedVolume('a', False)])
-        assert_b = lambda b: self.assertItemsEqual(get_shared_host_volumes(b), [SharedVolume('a', False),
-                                                                                SharedVolume('b', True),
-                                                                                SharedVolume(('c', 'ch'), False),
-                                                                                SharedVolume(('d', 'dh'), True)])
+        assert_b = lambda b: six.assertCountEqual(self, get_shared_host_volumes(b), [SharedVolume('a', False),
+                                                                                     SharedVolume('b', True),
+                                                                                     SharedVolume(('c', 'ch'), False),
+                                                                                     SharedVolume(('d', 'dh'), True)])
 
         assert_a('a')
         assert_a([('a', )])
@@ -104,8 +105,8 @@ class InputConversionTest(unittest.TestCase):
 
     def test_get_container_links(self):
         assert_a = lambda a: self.assertEqual(get_container_links(a), [ContainerLink('a', 'a')])
-        assert_b = lambda b: self.assertItemsEqual(get_container_links(b), [ContainerLink('a', 'a'),
-                                                                            ContainerLink('b', 'b_')])
+        assert_b = lambda b: six.assertCountEqual(self, get_container_links(b), [ContainerLink('a', 'a'),
+                                                                                 ContainerLink('b', 'b_')])
 
         assert_a('a')
         assert_a((ContainerLink('a', 'a'), ))
@@ -127,9 +128,9 @@ class InputConversionTest(unittest.TestCase):
 
     def test_get_get_port_bindings(self):
         assert_a = lambda a: self.assertEqual(get_port_bindings(a), [PortBinding('1234', None, None)])
-        assert_b = lambda b: self.assertItemsEqual(get_port_bindings(b), [PortBinding('1234', None, None),
-                                                                          PortBinding(1234, 1234, None),
-                                                                          PortBinding(1235, 1235, '0.0.0.0')])
+        assert_b = lambda b: six.assertCountEqual(self, get_port_bindings(b), [PortBinding('1234', None, None),
+                                                                               PortBinding(1234, 1234, None),
+                                                                               PortBinding(1235, 1235, '0.0.0.0')])
 
         assert_a('1234')
         assert_a(PortBinding('1234', None, None))

--- a/tests/test_value_resolution.py
+++ b/tests/test_value_resolution.py
@@ -112,4 +112,4 @@ class LazyValueResolutionTest(unittest.TestCase):
         self.assertIsInstance(data['d'][2]['a'], lazy_once)
         self.assertFalse(data['d'][2]['a'].evaluated)
         # Placing functions as dictionary keys may not be a good idea, but should work at least for tuples.
-        self.assertDictContainsSubset(dict(test_value_2='e'), data)
+        self.assertEqual(data.get('test_value_2'), 'e')


### PR DESCRIPTION
I stumbled on this project and really liked it (it looks like what I'm trying to do myself), but even though `setup.py` says it supports Python 3, tests don't pass at all under Python 3.

This PR is a list of fixes to make all tests pass. It also removes a deprecation warning.

Now I can actually try the library...