### PR TITLE
Fix image building under Python 3

### DIFF
--- a/dockermap/build/buffer.py
+++ b/dockermap/build/buffer.py
@@ -4,10 +4,7 @@ from __future__ import unicode_literals
 from abc import ABCMeta, abstractmethod
 from six import with_metaclass
 from tempfile import NamedTemporaryFile
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import BytesIO
 
 
 class FinalizedError(Exception):
@@ -99,9 +96,9 @@ class DockerBuffer(with_metaclass(ABCMeta, object)):
 
 class DockerStringBuffer(with_metaclass(ABCMeta, DockerBuffer)):
     """
-    Partial implementation of :class:`~DockerBuffer`, backed by a :class:`~StringIO` buffer.
+    Partial implementation of :class:`~DockerBuffer`, backed by a :class:`~BytesIO` buffer.
     """
-    init_fileobj = StringIO
+    init_fileobj = BytesIO
 
     def save(self, name, encoding='utf-8'):
         """

--- a/dockermap/build/dockerfile.py
+++ b/dockermap/build/dockerfile.py
@@ -440,7 +440,7 @@ class DockerFile(DockerStringBuffer):
                 self.prefix('RUN', 'rm -Rf', filename)
             self.blank()
         if self._volumes is not None:
-            self.prefix('VOLUME', json.dumps(self._volumes, encoding='utf-8'))
+            self.prefix('VOLUME', json.dumps(self._volumes))
         if self._cmd_user:
             self.prefix('USER', self._cmd_user)
         if self._cmd_workdir:

--- a/dockermap/build/dockerfile.py
+++ b/dockermap/build/dockerfile.py
@@ -72,9 +72,9 @@ def format_command(cmd, shell=False):
             return cmd
     else:
         if isinstance(cmd, (list, tuple)):
-            return json.dumps(cmd, encoding='utf-8')
+            return json.dumps(cmd)
         elif isinstance(cmd, six.string_types):
-            return json.dumps([c for c in _split_cmd()], encoding='utf-8')
+            return json.dumps([c for c in _split_cmd()])
     raise ValueError("Invalid type of command string or sequence: {0}".format(cmd))
 
 

--- a/dockermap/build/dockerfile.py
+++ b/dockermap/build/dockerfile.py
@@ -293,7 +293,7 @@ class DockerFile(DockerStringBuffer):
         :type input_str: unicode
         """
         self.check_not_finalized()
-        self.fileobj.write(input_str)
+        self.fileobj.write(input_str.encode('utf-8'))
 
     def writelines(self, sequence):
         """
@@ -307,8 +307,8 @@ class DockerFile(DockerStringBuffer):
 
     def writeline(self, input_str):
         self.check_not_finalized()
-        self.fileobj.write(input_str)
-        self.fileobj.write('\n')
+        self.fileobj.write(input_str.encode('utf-8'))
+        self.fileobj.write(b'\n')
 
     @property
     def volumes(self):

--- a/dockermap/utils.py
+++ b/dockermap/utils.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import json
 import os
+import six
 
 from .functional import lazy_once
 
@@ -21,8 +22,10 @@ def parse_response(response):
     :return: Decoded object from the JSON string. Returns an empty dictionary if input was invalid.
     :rtype: dict
     """
+    if isinstance(response, six.binary_type):
+        response = response.decode('utf-8')
     try:
-        obj = json.loads(response.decode('utf-8'))
+        obj = json.loads(response)
     except ValueError:
         return {}
     return obj

--- a/dockermap/utils.py
+++ b/dockermap/utils.py
@@ -22,7 +22,7 @@ def parse_response(response):
     :rtype: dict
     """
     try:
-        obj = json.loads(response, encoding='utf-8')
+        obj = json.loads(response.decode('utf-8'))
     except ValueError:
         return {}
     return obj


### PR DESCRIPTION
When building a dockermap-generated Dockerfile under Python 3, we would
raise an exception in `DockerContext.add_dockerfile()` at line
`self.tarfile.addfile(tarinfo, dockerfile_obj)` because bytes are
expected, not strings (which is what `StringIO` stores).

I've fixed this by replacing `StringIO` by `BytesIO` and encoding
strings in `Dockerfile.write*()`.

Also, fixed a bytes/str-related crash in the JSON parsing of the
response stream.

Sorry about the lack of tests, I really don't know the library enough to
write them (I haven't managed to successfully use it yet).