### PR TITLE
Handle Network Config in _transform_create_kwargs

### DIFF
--- a/dockermap/client/cli.py
+++ b/dockermap/client/cli.py
@@ -144,7 +144,15 @@ def _transform_host_config(ka):
             elif key == "Links":
                 yield _quoted_arg_format('link', item)
             elif key == 'PortBindings':
-                yield _mapping_format('publish', item)
+                for dest_dict in value[item]:
+                    destination = dest_dict['HostPort']
+                    if dest_dict['HostIp']:
+                        destination = '{}:{}'.format(dest_dict['HostIp'], destination)
+                    yield _mapping_format(
+                        'publish',
+                        item,
+                        destination,
+                    )
 
 
 def _transform_create_kwargs(ka):

--- a/dockermap/client/cli.py
+++ b/dockermap/client/cli.py
@@ -149,7 +149,7 @@ def _transform_host_config(ka):
                     if source_dict['HostIp']:
                         source = '{}:{}'.format(source_dict['HostIp'], source)
                     yield _mapping_format(
-                        'expose',
+                        'publish',
                         source,
                         item,
                     )

--- a/dockermap/client/cli.py
+++ b/dockermap/client/cli.py
@@ -149,7 +149,7 @@ def _transform_host_config(ka):
                     if dest_dict['HostIp']:
                         destination = '{}:{}'.format(dest_dict['HostIp'], destination)
                     yield _mapping_format(
-                        'publish',
+                        'expose',
                         item,
                         destination,
                     )

--- a/dockermap/client/cli.py
+++ b/dockermap/client/cli.py
@@ -144,14 +144,14 @@ def _transform_host_config(ka):
             elif key == "Links":
                 yield _quoted_arg_format('link', item)
             elif key == 'PortBindings':
-                for dest_dict in value[item]:
-                    destination = dest_dict['HostPort']
-                    if dest_dict['HostIp']:
-                        destination = '{}:{}'.format(dest_dict['HostIp'], destination)
+                for source_dict in value[item]:
+                    source = source_dict['HostPort']
+                    if source_dict['HostIp']:
+                        source = '{}:{}'.format(source_dict['HostIp'], source)
                     yield _mapping_format(
                         'expose',
+                        source,
                         item,
-                        destination,
                     )
 
 

--- a/dockermap/client/cli.py
+++ b/dockermap/client/cli.py
@@ -132,7 +132,23 @@ def _transform_kwargs(ka):
             yield _quoted_arg_format(cmd_arg, value)
 
 
+def _transform_host_config(ka):
+    for key, value in iteritems(ka):
+        if key == 'NetworkMode':
+            if value != 'default':
+                yield _quoted_arg_format('network', value)
+            continue
+        for item in value:
+            if key == "Binds":
+                yield _quoted_arg_format('volume', item)
+            elif key == "Links":
+                yield _quoted_arg_format('link', item)
+            elif key == 'PortBindings':
+                yield _mapping_format('publish', item)
+
+
 def _transform_create_kwargs(ka):
+    host_config = ka.pop('host_config', None)
     network = ka.pop('network_mode', None)
     network_disabled = ka.pop('network_disabled', False)
     network_config = ka.pop('networking_config', None)
@@ -145,6 +161,9 @@ def _transform_create_kwargs(ka):
     restart_policy = ka.pop('restart_policy', None)
 
     for arg in _transform_kwargs(ka):
+        yield arg
+
+    for arg in _transform_host_config(host_config):
         yield arg
 
     if environment:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ class TransformCreateKwargs(TestCase):
                 links=[('from', 'to')],
             )
         }
-        final_kwargs = _transform_create_kwargs(initial_kwargs)
+        final_kwargs = _transform_create_kwargs(initial_kwargs.copy())
         self.assertIn(
             '--link="from:to"',
             final_kwargs
@@ -27,9 +27,22 @@ class TransformCreateKwargs(TestCase):
                 binds=['/var/lib/site/config/app1:/var/lib/app/config:ro'],
             )
         }
-        final_kwargs = _transform_create_kwargs(initial_kwargs)
+        final_kwargs = _transform_create_kwargs(initial_kwargs.copy())
         self.assertIn(
             '--volume="/var/lib/site/config/app1:/var/lib/app/config:ro"',
+            final_kwargs
+        )
+
+    def test_port(self):
+        initial_kwargs = {
+            'host_config': HostConfig(
+                version='1.25',
+                port_bindings={8080: 80},
+            )
+        }
+        final_kwargs = _transform_create_kwargs(initial_kwargs.copy())
+        self.assertIn(
+            '--publish=8080/tcp:80',
             final_kwargs
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,7 +42,7 @@ class TransformCreateKwargs(TestCase):
         }
         final_kwargs = _transform_create_kwargs(initial_kwargs.copy())
         self.assertIn(
-            '--publish=8080/tcp:80',
+            '--expose=8080/tcp:80',
             final_kwargs
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,12 +37,12 @@ class TransformCreateKwargs(TestCase):
         initial_kwargs = {
             'host_config': HostConfig(
                 version='1.25',
-                port_bindings={8080: 80},
+                port_bindings={80: 8080},
             )
         }
         final_kwargs = _transform_create_kwargs(initial_kwargs.copy())
         self.assertIn(
-            '--expose=8080/tcp:80',
+            '--expose=8080:80/tcp',
             final_kwargs
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,7 +42,7 @@ class TransformCreateKwargs(TestCase):
         }
         final_kwargs = _transform_create_kwargs(initial_kwargs.copy())
         self.assertIn(
-            '--expose=8080:80/tcp',
+            '--publish=8080:80/tcp',
             final_kwargs
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,35 @@
+from unittest import TestCase
+
+from docker.types import HostConfig
+
+from dockermap.client.cli import _transform_create_kwargs
+
+
+class TransformCreateKwargs(TestCase):
+
+    def test_link(self):
+        initial_kwargs = {
+            'host_config': HostConfig(
+                version='1.25',
+                links=[('from', 'to')],
+            )
+        }
+        final_kwargs = _transform_create_kwargs(initial_kwargs)
+        self.assertIn(
+            '--link="from:to"',
+            final_kwargs
+        )
+
+    def test_host(self):
+        initial_kwargs = {
+            'host_config': HostConfig(
+                version='1.25',
+                binds=['/var/lib/site/config/app1:/var/lib/app/config:ro'],
+            )
+        }
+        final_kwargs = _transform_create_kwargs(initial_kwargs)
+        self.assertIn(
+            '--volume="/var/lib/site/config/app1:/var/lib/app/config:ro"',
+            final_kwargs
+        )
+


### PR DESCRIPTION
This begins to address the issue in merll/docker-fabric#18 by explicitly handling the new `host_config` flag in the kwargs.